### PR TITLE
`reduce.py` updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 filepath.py
+tests/
+run_reduce.py

--- a/process.py
+++ b/process.py
@@ -46,10 +46,10 @@ def logm(m,string):
     if type(string) is list:
         for s in string:
             m.append(s+'\n')
-            print s
+            print(s)
     else:
         m.append(string+'\n')
-        print string    
+        print(string)    
 
 
 def loghistory(message):
@@ -59,9 +59,9 @@ def loghistory(message):
 
 def log_inputs(p):
     '''starting the history file and log the input files used'''
-    print 'Recording the reduction process in: '
-    print filepath.calibdata+dnight+'/processlog.txt'
-    print ' '
+    print('Recording the reduction process in: ')
+    print(filepath.calibdata+dnight+'/processlog.txt')
+    print(' ')
     m = []
     logm(m,'%s processed on %s by %s' %(p[0],str(Dtime.now())[:19],p[6]))
     logm(m,'')
@@ -98,7 +98,7 @@ def reduce_images(*args):
     '''Basic image reduction'''
     update_progressbar(0,i)
     t1 = time.time()
-    print 'Reducing images... '
+    print('Reducing images... ')
     import reduce as R
     if 'V' in args[2]:
         R.reducev(args[0],args[1],args[2]['V'],args[3])
@@ -160,7 +160,7 @@ def apply_filter(*args):
     t1 = time.time()
     import medianfilter
     for filter in args[2]:
-        print 'Applying median filter to %s-band images' %filter
+        print('Applying median filter to %s-band images' %filter)
         medianfilter.filter(args[0],args[1],filter)
     t2 = time.time()
     args[-1].put(t2-t1)
@@ -179,7 +179,7 @@ def mosaic_galactic(*args):
     '''Creates the mosaic of the galactic model'''
     t1 = time.time()
     import galactic
-    print 'Creating the mosaic of the galactic model'
+    print('Creating the mosaic of the galactic model')
     galactic.mosaic(*args[:-1])
     t2 = time.time()
     args[-1].put(t2-t1)
@@ -189,7 +189,7 @@ def mosaic_zodiacal(*args):
     '''Creates the mosaic of the zodiacal model'''
     t1 = time.time()
     import zodiacal
-    print 'Creating the mosaic of the zodiacal model' 
+    print('Creating the mosaic of the zodiacal model')
     zodiacal.mosaic(*args[:-1])
     t2 = time.time()
     args[-1].put(t2-t1)
@@ -200,7 +200,7 @@ def mosaic_full(*args):
     t1 = time.time()
     import fullmosaic
     for filter in args[2]:
-        print 'Creating the mosaic from full-resolution %s-band images' %filter
+        print('Creating the mosaic from full-resolution %s-band images' %filter)
         fullmosaic.mosaic(args[0],args[1],filter)
     t2 = time.time()
     args[-1].put(t2-t1)
@@ -211,7 +211,7 @@ def mosaic_median(*args):
     t1 = time.time()
     import medianmosaic
     for filter in args[2]:
-        print 'Creating the mosaic from median-filtered %s-band images' %filter
+        print('Creating the mosaic from median-filtered %s-band images' %filter)
         medianmosaic.mosaic(args[0],args[1],filter)
     t2 = time.time()
     args[-1].put(t2-t1)
@@ -223,13 +223,13 @@ import numpy as n
 if __name__ == '__main__':
     t1 = time.time()
     #-----------------------------------------------------------------------------#    
-    print ' '
-    print '--------------------------------------------------------------'
-    print ' '
-    print '        NPS NIGHT SKIES PROGRAM RAW IMAGE PROCESSING'
-    print ' '
-    print '--------------------------------------------------------------'
-    print ' '
+    print(' ')
+    print('--------------------------------------------------------------')
+    print(' ')
+    print('        NPS NIGHT SKIES PROGRAM RAW IMAGE PROCESSING')
+    print(' ')
+    print('--------------------------------------------------------------')
+    print(' ')
     
     #-----------------------------------------------------------------------------#
     #Standard libraries
@@ -282,7 +282,7 @@ if __name__ == '__main__':
     if all(Processor == 'L_Hung2'):
         barfig.canvas.manager.window.move(2755,0)  
     else:
-        print 'You have 5 seconds to adjust the position of the progress bar window'
+        print('You have 5 seconds to adjust the position of the progress bar window')
         plt.pause(5) #users have 5 seconds to adjust the figure position
     
     #Progress bar array (to be filled with processing time)
@@ -352,7 +352,7 @@ if __name__ == '__main__':
         barfig.savefig(filepath.calibdata+Dataset[i]+'/processtime.png')
         
     t2 = time.time()
-    print 'Total processing time: %.1f min' %((t2-t1)/60)
+    print('Total processing time: %.1f min' %((t2-t1)/60))
     loghistory(['Total processing time: %.1f min' %((t2-t1)/60),])
     history.close()
     

--- a/reduce.py
+++ b/reduce.py
@@ -33,7 +33,6 @@ from astropy.io import fits
 from glob import glob, iglob
 from PIL import Image
 
-import pdb
 import PIL
 import matplotlib.pyplot as plt
 import numpy as n

--- a/reduce.py
+++ b/reduce.py
@@ -55,7 +55,7 @@ def reducev(dnight, sets, flatname, curve):
     #read in the flat
     flat = fits.open(filepath.flats+flatname,unit=False)[0].data
     
-    T = Dispatch('Maxim.Document')
+    #T = Dispatch('Maxim.Document')
     
     #looping through all the sets in that night
     for s in sets:
@@ -126,9 +126,9 @@ def reducev(dnight, sets, flatname, curve):
             f.data /= flat                        # divide by flat
             f.header['IMAGETYP'] = 'CALIB_M'
             f.writeto(calsetp+file[i][len(rawsetp):], overwrite=True)
-            T.OpenFile(calsetp+file[i][len(rawsetp):])
-            T.SaveFile(calsetp+'tiff/'+file[i][len(rawsetp):-4]+'.tif',5,False,1,0)
-            T.Close            #imsave(calsetp+'tiff/'+file[i][len(rawsetp):-4]+'.tif', f.data)
+            #T.OpenFile(calsetp+file[i][len(rawsetp):])
+            #T.SaveFile(calsetp+'tiff/'+file[i][len(rawsetp):-4]+'.tif',5,False,1,0)
+            #T.Close            #imsave(calsetp+'tiff/'+file[i][len(rawsetp):-4]+'.tif', f.data)
         
         for f in iglob(filepath.tiff+'*.tfw'):
             shutil.copy2(f,calsetp+'tiff/')
@@ -148,7 +148,7 @@ def reduceb(dnight, sets, flatname, curve):
     #read in the flat
     flat = fits.open(filepath.flats+flatname,unit=False)[0].data
     
-    T = Dispatch('Maxim.Document')
+    #T = Dispatch('Maxim.Document')
 
     #looping through all the sets in that night
     for s in sets:
@@ -177,13 +177,13 @@ def reduceb(dnight, sets, flatname, curve):
             f.data /= flat                        # divide by flat
             f.header['IMAGETYP'] = 'CALIB_M'
             f.writeto(calsetp+file[i][len(rawsetp):-5]+'.fit', overwrite=True)
-            T.OpenFile(calsetp+file[i][len(rawsetp):-5]+'.fit')
-            T.SaveFile(calsetp+'tiff/'+file[i][len(rawsetp):-5]+'.tif',5,False,1,0)
-            T.Close
+            #T.OpenFile(calsetp+file[i][len(rawsetp):-5]+'.fit')
+            #T.SaveFile(calsetp+'tiff/'+file[i][len(rawsetp):-5]+'.tif',5,False,1,0)
+            #T.Close
             #imsave(calsetp+'tiff/'+file[i][len(rawsetp):-5]+'.tif', f.data)
         
         for f in iglob(filepath.tiff+'*.tfw'):
-            shutil.copy2(f,calsetp+'tiff/') 
+            shutil.copy2(f,calsetp+'tiff/')
             
     #close MaxIm_DL application
     os.system('taskkill /f /im MaxIm_DL.exe')

--- a/reduce.py
+++ b/reduce.py
@@ -134,7 +134,7 @@ def reducev(dnight, sets, flatname, curve):
             shutil.copy2(f,calsetp+'tiff/')
 
     #close MaxIm_DL application
-    os.system('taskkill /f /im MaxIm_DL.exe')
+    #os.system('taskkill /f /im MaxIm_DL.exe')
                     
 
 def reduceb(dnight, sets, flatname, curve):
@@ -186,5 +186,5 @@ def reduceb(dnight, sets, flatname, curve):
             shutil.copy2(f,calsetp+'tiff/')
             
     #close MaxIm_DL application
-    os.system('taskkill /f /im MaxIm_DL.exe')
+    #os.system('taskkill /f /im MaxIm_DL.exe')
                         

--- a/reduce.py
+++ b/reduce.py
@@ -31,8 +31,9 @@
 
 from astropy.io import fits
 from glob import glob, iglob
+from PIL import Image
 #from scipy.misc import imsave 
-from win32com.client import Dispatch
+#from win32com.client import Dispatch
 
 import pdb
 import matplotlib.pyplot as plt
@@ -50,7 +51,7 @@ def reducev(dnight, sets, flatname, curve):
     This module is for calibrating the V-band data.
     '''
     #read in the linearity curve (ADU, multiplying factor)
-    xp, fp = n.loadtxt(filepath.lincurve+curve+'.txt', unpack=True)
+    xp, fp = n.loadtxt(filepath.lincurve+curve+'.txt', unpack=True, delimiter=",")
     
     #read in the flat
     flat = fits.open(filepath.flats+flatname,unit=False)[0].data
@@ -126,6 +127,14 @@ def reducev(dnight, sets, flatname, curve):
             f.data /= flat                        # divide by flat
             f.header['IMAGETYP'] = 'CALIB_M'
             f.writeto(calsetp+file[i][len(rawsetp):], overwrite=True)
+
+            # Save as TIFF file
+            tiff_data = f.data.astype(n.uint16)
+            tiff_output = Image.fromarray(tiff_data, mode="I;16")
+            tiff_output.save(
+                calsetp+'tiff/'+file[i][len(rawsetp):-4]+'.tif',
+                compression=None
+            )
             #T.OpenFile(calsetp+file[i][len(rawsetp):])
             #T.SaveFile(calsetp+'tiff/'+file[i][len(rawsetp):-4]+'.tif',5,False,1,0)
             #T.Close            #imsave(calsetp+'tiff/'+file[i][len(rawsetp):-4]+'.tif', f.data)
@@ -177,6 +186,13 @@ def reduceb(dnight, sets, flatname, curve):
             f.data /= flat                        # divide by flat
             f.header['IMAGETYP'] = 'CALIB_M'
             f.writeto(calsetp+file[i][len(rawsetp):-5]+'.fit', overwrite=True)
+
+            tiff_data = f.data.astype(n.uint16)
+            tiff_output = Image.fromarray(tiff_data, mode="I;16")
+            tiff_output.save(
+                calsetp+'tiff/'+file[i][len(rawsetp):-4]+'.tif',
+                compression=None
+            )
             #T.OpenFile(calsetp+file[i][len(rawsetp):-5]+'.fit')
             #T.SaveFile(calsetp+'tiff/'+file[i][len(rawsetp):-5]+'.tif',5,False,1,0)
             #T.Close

--- a/reduce.py
+++ b/reduce.py
@@ -32,10 +32,9 @@
 from astropy.io import fits
 from glob import glob, iglob
 from PIL import Image
-#from scipy.misc import imsave 
-#from win32com.client import Dispatch
 
 import pdb
+import PIL
 import matplotlib.pyplot as plt
 import numpy as n
 import os
@@ -55,8 +54,6 @@ def reducev(dnight, sets, flatname, curve):
     
     #read in the flat
     flat = fits.open(filepath.flats+flatname,unit=False)[0].data
-    
-    #T = Dispatch('Maxim.Document')
     
     #looping through all the sets in that night
     for s in sets:
@@ -120,30 +117,37 @@ def reducev(dnight, sets, flatname, curve):
                          rawsetp+'zenith2.fit'))
             
         for i in range(len(file)):
-            f = fits.open(file[i],uint=False)[0]  # science image 
-            f.data -= combias+biasdrift[i]        # subtract drift-corrected bias
-            f.data *= n.interp(f.data,xp,fp)      # correct for linearity response
-            f.data -= corthermal                  # subtract dark
-            f.data /= flat                        # divide by flat
-            f.header['IMAGETYP'] = 'CALIB_M'
-            f.writeto(calsetp+file[i][len(rawsetp):], overwrite=True)
 
-            # Save as TIFF file
+            with fits.open(file[i],uint=False) as hdu:
+                f = hdu[0]                            # science image 
+                f.data -= combias+biasdrift[i]        # subtract drift-corrected bias
+                f.data *= n.interp(f.data,xp,fp)      # correct for linearity response
+                f.data -= corthermal                  # subtract dark
+                f.data /= flat                        # divide by flat
+                f.header['IMAGETYP'] = 'CALIB_M'      # Update header
+                f.writeto(calsetp+file[i][len(rawsetp):], overwrite=True)
+
+            # Save as TIFF file. TIFF Tag IDs found here:
+            # https://www.itu.int/itudoc/itu-t/com16/tiff-fx/docs/tiff6.pdf
             tiff_data = f.data.astype(n.uint16)
+            software_info = f'pillow (PIL) version {PIL.__version__}'
+            tiff_info = {
+                270: f.header['OBJECT'],   # Description
+                305: software_info,        # Software
+                259: 1,                    # Compression (1 = None)
+                282: 1058,                 # X Resolution (set to match MaximDL TIFFs)
+                283: 1058,                 # Y Resolution (set to match MaximDL TIFFs)
+                296: 2,                    # 2 = dpi
+                271: f.header['INSTRUME']  # Camera Maker
+            }
             tiff_output = Image.fromarray(tiff_data, mode="I;16")
             tiff_output.save(
                 calsetp+'tiff/'+file[i][len(rawsetp):-4]+'.tif',
-                compression=None
+                tiffinfo = tiff_info
             )
-            #T.OpenFile(calsetp+file[i][len(rawsetp):])
-            #T.SaveFile(calsetp+'tiff/'+file[i][len(rawsetp):-4]+'.tif',5,False,1,0)
-            #T.Close            #imsave(calsetp+'tiff/'+file[i][len(rawsetp):-4]+'.tif', f.data)
         
         for f in iglob(filepath.tiff+'*.tfw'):
             shutil.copy2(f,calsetp+'tiff/')
-
-    #close MaxIm_DL application
-    #os.system('taskkill /f /im MaxIm_DL.exe')
                     
 
 def reduceb(dnight, sets, flatname, curve):
@@ -156,8 +160,6 @@ def reduceb(dnight, sets, flatname, curve):
     
     #read in the flat
     flat = fits.open(filepath.flats+flatname,unit=False)[0].data
-    
-    #T = Dispatch('Maxim.Document')
 
     #looping through all the sets in that night
     for s in sets:
@@ -187,21 +189,25 @@ def reduceb(dnight, sets, flatname, curve):
             f.header['IMAGETYP'] = 'CALIB_M'
             f.writeto(calsetp+file[i][len(rawsetp):-5]+'.fit', overwrite=True)
 
-            # Save as TIFF file
+            # Save as TIFF file. TIFF Tag IDs found here:
+            # https://www.itu.int/itudoc/itu-t/com16/tiff-fx/docs/tiff6.pdf
             tiff_data = f.data.astype(n.uint16)
+            software_info = f'pillow (PIL) version {PIL.__version__}'
+            tiff_info = {
+                270: f.header['OBJECT'],   # Description
+                305: software_info,        # Software
+                259: 1,                    # Compression (1 = None)
+                282: 1058,                 # X Resolution (set to match MaximDL TIFFs)
+                283: 1058,                 # Y Resolution (set to match MaximDL TIFFs)
+                296: 2,                    # 2 = dpi
+                271: f.header['INSTRUME']  # Camera Maker
+            }
             tiff_output = Image.fromarray(tiff_data, mode="I;16")
             tiff_output.save(
                 calsetp+'tiff/'+file[i][len(rawsetp):-4]+'.tif',
-                compression=None
+                tiffinfo = tiff_info
             )
-            #T.OpenFile(calsetp+file[i][len(rawsetp):-5]+'.fit')
-            #T.SaveFile(calsetp+'tiff/'+file[i][len(rawsetp):-5]+'.tif',5,False,1,0)
-            #T.Close
-            #imsave(calsetp+'tiff/'+file[i][len(rawsetp):-5]+'.tif', f.data)
         
         for f in iglob(filepath.tiff+'*.tfw'):
             shutil.copy2(f,calsetp+'tiff/')
-            
-    #close MaxIm_DL application
-    #os.system('taskkill /f /im MaxIm_DL.exe')
                         

--- a/reduce.py
+++ b/reduce.py
@@ -137,7 +137,7 @@ def reducev(dnight, sets, flatname, curve):
                 259: 1,                    # Compression (1 = None)
                 282: 1058,                 # X Resolution (set to match MaximDL TIFFs)
                 283: 1058,                 # Y Resolution (set to match MaximDL TIFFs)
-                296: 2,                    # 2 = dpi
+                296: 2,                    # Resolution unit (2 = dpi)
                 271: f.header['INSTRUME']  # Camera Maker
             }
             tiff_output = Image.fromarray(tiff_data, mode="I;16")
@@ -199,7 +199,7 @@ def reduceb(dnight, sets, flatname, curve):
                 259: 1,                    # Compression (1 = None)
                 282: 1058,                 # X Resolution (set to match MaximDL TIFFs)
                 283: 1058,                 # Y Resolution (set to match MaximDL TIFFs)
-                296: 2,                    # 2 = dpi
+                296: 2,                    # Resolution unit (2 = dpi)
                 271: f.header['INSTRUME']  # Camera Maker
             }
             tiff_output = Image.fromarray(tiff_data, mode="I;16")

--- a/reduce.py
+++ b/reduce.py
@@ -187,6 +187,7 @@ def reduceb(dnight, sets, flatname, curve):
             f.header['IMAGETYP'] = 'CALIB_M'
             f.writeto(calsetp+file[i][len(rawsetp):-5]+'.fit', overwrite=True)
 
+            # Save as TIFF file
             tiff_data = f.data.astype(n.uint16)
             tiff_output = Image.fromarray(tiff_data, mode="I;16")
             tiff_output.save(

--- a/reduce.py
+++ b/reduce.py
@@ -61,9 +61,9 @@ def reducev(dnight, sets, flatname, curve):
     for s in sets:
         rawsetp = filepath.rawdata + dnight + '/' + s + '/'
         calsetp = filepath.calibdata + dnight + '/S_0' + s[0] + '/'
-        print dnight + '/' + s + '...'
+        print(dnight + '/' + s + '...')
         if os.path.isdir(calsetp):
-            print 'Replacing old calibrated files...'
+            print('Replacing old calibrated files...')
         else:
             os.makedirs(calsetp)
             os.makedirs(calsetp+'tiff/')
@@ -154,9 +154,9 @@ def reduceb(dnight, sets, flatname, curve):
     for s in sets:
         rawsetp = filepath.rawdata + dnight + '/' + s + '/'
         calsetp = filepath.calibdata + dnight + '/S_0' + s[0] + '/B/'
-        print dnight + '/' + s + '...'
+        print(dnight + '/' + s + '...')
         if os.path.isdir(calsetp):
-            print 'Replacing old calibrated files...'
+            print('Replacing old calibrated files...')
         else:
             os.makedirs(calsetp)
             os.makedirs(calsetp+'tiff/')

--- a/reduce.py
+++ b/reduce.py
@@ -31,7 +31,7 @@
 
 from astropy.io import fits
 from glob import glob, iglob
-from scipy.misc import imsave 
+#from scipy.misc import imsave 
 from win32com.client import Dispatch
 
 import pdb


### PR DESCRIPTION
Includes updates from python 2.x to 3.x and now converts FITS images into TIFF images using [pillow (PIL)](https://pillow.readthedocs.io/en/stable/index.html) instead of MaximDL. Updated script was tested using python 3.12.