### PR TITLE
`register.py` updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 filepath.py
 tests/
 run_reduce.py
+run_register.py

--- a/client.py
+++ b/client.py
@@ -56,11 +56,11 @@ class Client(object):
         '''
         if self.session is not None:
             args.update({ 'session' : self.session })
-        print('Python:', args)
+        #print('Python:', args)
         json = python2json(args)
-        print('Sending json:', json)
+        #print('Sending json:', json)
         url = self.get_url(service)
-        print('Sending to URL:', url)
+        #print('Sending to URL:', url)
 
         # If we're sending a file, format a multipart/form-data
         if file_args is not None:
@@ -88,10 +88,10 @@ class Client(object):
         else:
             # Else send x-www-form-encoded
             data = {'request-json': json}
-            print('Sending form data:', data)
+            #print('Sending form data:', data)
             data = urlencode(data)
             data = data.encode('utf-8')
-            print('Sending data:', data)
+            #print('Sending data:', data)
             headers = {}
 
         request = Request(url=url, headers=headers, data=data)
@@ -99,11 +99,11 @@ class Client(object):
         try:
             f = urlopen(request)
             txt = f.read()
-            print('Got json:', txt)
+            #print('Got json:', txt)
             result = json2python(txt)
-            print('Got result:', result)
+            #print('Got result:', result)
             stat = result.get('status')
-            print('Got status:', stat)
+            #print('Got status:', stat)
             if stat == 'error':
                 errstr = result.get('errormessage', '(none)')
                 raise RequestError('server error message: ' + errstr)
@@ -118,7 +118,7 @@ class Client(object):
         args = { 'apikey' : apikey }
         result = self.send_request('login', args)
         sess = result.get('session')
-        print('Got session:', sess)
+        #print('Got session:', sess)
         if not sess:
             raise RequestError('no session in result')
         self.session = sess
@@ -155,7 +155,7 @@ class Client(object):
                 args.update({key: val})
             elif default is not None:
                 args.update({key: default})
-        print('Upload args:', args)
+        #print('Upload args:', args)
         return args
 
     def url_upload(self, url, **kwargs):
@@ -237,7 +237,7 @@ class Client(object):
         return result
 
 if __name__ == '__main__':
-    print("Running with args %s"%sys.argv)
+    #print("Running with args %s"%sys.argv)
     import optparse
     parser = optparse.OptionParser()
     parser.add_option('--server', dest='server', default=Client.default_url,
@@ -321,6 +321,10 @@ if __name__ == '__main__':
     c = Client(**args)
     c.login(opt.apikey)
 
+    # Print out starting message
+    img_name = opt.upload.split("\\")[-1]
+    print(f'  Solving image {img_name}...')
+    
     if opt.upload or opt.upload_url:
         if opt.wcs or opt.kmz or opt.newfits or opt.corr or opt.annotate or opt.calibrate:
             opt.wait = True
@@ -374,26 +378,26 @@ if __name__ == '__main__':
 
             while True:
                 stat = c.sub_status(opt.sub_id, justdict=True)
-                print('Got status:', stat)
+                #print('Got status:', stat)
                 jobs = stat.get('jobs', [])
                 if len(jobs):
                     for j in jobs:
                         if j is not None:
                             break
                     if j is not None:
-                        print('Selecting job id', j)
+                        #print('Selecting job id', j)
                         opt.solved_id = j
                         break
                 time.sleep(5)
 
         while True:
             stat = c.job_status(opt.solved_id, justdict=True)
-            print('Got job status:', stat)
+            #print('Got job status:', stat)
             if stat.get('status','') in ['success']:
                 success = (stat['status'] == 'success')
                 break
             elif stat.get('status','') in ['failure']:
-                print("Image solving failed")
+                print(f"  Image solving FAILED for {img_name}")
                 sys.exit(-1)
             time.sleep(5)
 
@@ -415,13 +419,13 @@ if __name__ == '__main__':
             retrieveurls.append((url, opt.corr))
 
         for url,fn in retrieveurls:
-            print('Retrieving file from', url, 'to', fn)
+            #print('Retrieving file from', url, 'to', fn)
             f = urlopen(url)
             txt = f.read()
             w = open(fn, 'wb')
             w.write(txt)
             w.close()
-            print('Wrote to', fn)
+            #print('Wrote to', fn)
 
         if opt.annotate:
             result = c.annotate_data(opt.solved_id)
@@ -459,3 +463,5 @@ if __name__ == '__main__':
     if opt.myjobs:
         jobs = c.myjobs()
         print(jobs)
+
+    print(f'  {img_name} Finished.')

--- a/client.py
+++ b/client.py
@@ -376,7 +376,6 @@ if __name__ == '__main__':
 
             while True:
                 stat = c.sub_status(opt.sub_id, justdict=True)
-                #print('Got status:', stat)
                 jobs = stat.get('jobs', [])
                 if len(jobs):
                     for j in jobs:

--- a/client.py
+++ b/client.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+
+# This file is part of the Astrometry.net suite.
+# Copyright 2009 Dustin Lang
+# Licensed under a 3-clause BSD style license - see LICENSE
+# https://github.com/dstndstn/astrometry.net
+
+from __future__ import print_function
+import os
+import sys
+import time
+import base64
+
+# py3
+from urllib.parse import urlencode, quote
+from urllib.request import urlopen, Request
+from urllib.error import HTTPError
+
+
+#from exceptions import Exception
+from email.mime.base import MIMEBase
+from email.mime.multipart import MIMEMultipart
+from email.mime.application  import MIMEApplication
+
+from email.encoders import encode_noop
+
+import json
+def json2python(data):
+    try:
+        return json.loads(data)
+    except:
+        pass
+    return None
+python2json = json.dumps
+
+class MalformedResponse(Exception):
+    pass
+class RequestError(Exception):
+    pass
+
+class Client(object):
+    default_url = 'https://nova.astrometry.net/api/'
+
+    def __init__(self,
+                 apiurl = default_url):
+        self.session = None
+        self.apiurl = apiurl
+
+    def get_url(self, service):
+        return self.apiurl + service
+
+    def send_request(self, service, args={}, file_args=None):
+        '''
+        service: string
+        args: dict
+        '''
+        if self.session is not None:
+            args.update({ 'session' : self.session })
+        print('Python:', args)
+        json = python2json(args)
+        print('Sending json:', json)
+        url = self.get_url(service)
+        print('Sending to URL:', url)
+
+        # If we're sending a file, format a multipart/form-data
+        if file_args is not None:
+            import random
+            boundary_key = ''.join([random.choice('0123456789') for i in range(19)])
+            boundary = '===============%s==' % boundary_key
+            headers = {'Content-Type':
+                       'multipart/form-data; boundary="%s"' % boundary}
+            data_pre = (
+                '--' + boundary + '\n' +
+                'Content-Type: text/plain\r\n' +
+                'MIME-Version: 1.0\r\n' +
+                'Content-disposition: form-data; name="request-json"\r\n' +
+                '\r\n' +
+                json + '\n' +
+                '--' + boundary + '\n' +
+                'Content-Type: application/octet-stream\r\n' +
+                'MIME-Version: 1.0\r\n' +
+                'Content-disposition: form-data; name="file"; filename="%s"' % file_args[0] +
+                '\r\n' + '\r\n')
+            data_post = (
+                '\n' + '--' + boundary + '--\n')
+            data = data_pre.encode() + file_args[1] + data_post.encode()
+
+        else:
+            # Else send x-www-form-encoded
+            data = {'request-json': json}
+            print('Sending form data:', data)
+            data = urlencode(data)
+            data = data.encode('utf-8')
+            print('Sending data:', data)
+            headers = {}
+
+        request = Request(url=url, headers=headers, data=data)
+
+        try:
+            f = urlopen(request)
+            txt = f.read()
+            print('Got json:', txt)
+            result = json2python(txt)
+            print('Got result:', result)
+            stat = result.get('status')
+            print('Got status:', stat)
+            if stat == 'error':
+                errstr = result.get('errormessage', '(none)')
+                raise RequestError('server error message: ' + errstr)
+            return result
+        except HTTPError as e:
+            print('HTTPError', e)
+            txt = e.read()
+            open('err.html', 'wb').write(txt)
+            print('Wrote error text to err.html')
+
+    def login(self, apikey):
+        args = { 'apikey' : apikey }
+        result = self.send_request('login', args)
+        sess = result.get('session')
+        print('Got session:', sess)
+        if not sess:
+            raise RequestError('no session in result')
+        self.session = sess
+
+    def _get_upload_args(self, **kwargs):
+        args = {}
+        for key,default,typ in [('allow_commercial_use', 'd', str),
+                                ('allow_modifications', 'd', str),
+                                ('publicly_visible', 'y', str),
+                                ('scale_units', None, str),
+                                ('scale_type', None, str),
+                                ('scale_lower', None, float),
+                                ('scale_upper', None, float),
+                                ('scale_est', None, float),
+                                ('scale_err', None, float),
+                                ('center_ra', None, float),
+                                ('center_dec', None, float),
+                                ('parity',None,int),
+                                ('radius', None, float),
+                                ('downsample_factor', None, int),
+                                ('positional_error', None, float),
+                                ('tweak_order', None, int),
+                                ('crpix_center', None, bool),
+                                ('invert', None, bool),
+                                ('image_width', None, int),
+                                ('image_height', None, int),
+                                ('x', None, list),
+                                ('y', None, list),
+                                ('album', None, str),
+                                ]:
+            if key in kwargs:
+                val = kwargs.pop(key)
+                val = typ(val)
+                args.update({key: val})
+            elif default is not None:
+                args.update({key: default})
+        print('Upload args:', args)
+        return args
+
+    def url_upload(self, url, **kwargs):
+        args = dict(url=url)
+        args.update(self._get_upload_args(**kwargs))
+        result = self.send_request('url_upload', args)
+        return result
+
+    def upload(self, fn=None, **kwargs):
+        args = self._get_upload_args(**kwargs)
+        file_args = None
+        if fn is not None:
+            try:
+                f = open(fn, 'rb')
+                file_args = (fn, f.read())
+            except IOError:
+                print('File %s does not exist' % fn)
+                raise
+        return self.send_request('upload', args, file_args)
+
+    def submission_images(self, subid):
+        result = self.send_request('submission_images', {'subid':subid})
+        return result.get('image_ids')
+
+
+    def myjobs(self):
+        result = self.send_request('myjobs/')
+        return result['jobs']
+
+    def job_status(self, job_id, justdict=False):
+        result = self.send_request('jobs/%s' % job_id)
+        if justdict:
+            return result
+        stat = result.get('status')
+        if stat == 'success':
+            result = self.send_request('jobs/%s/calibration' % job_id)
+            print('Calibration:', result)
+            result = self.send_request('jobs/%s/tags' % job_id)
+            print('Tags:', result)
+            result = self.send_request('jobs/%s/machine_tags' % job_id)
+            print('Machine Tags:', result)
+            result = self.send_request('jobs/%s/objects_in_field' % job_id)
+            print('Objects in field:', result)
+            result = self.send_request('jobs/%s/annotations' % job_id)
+            print('Annotations:', result)
+            result = self.send_request('jobs/%s/info' % job_id)
+            print('Calibration:', result)
+
+        return stat
+
+    def annotate_data(self,job_id):
+        """
+        :param job_id: id of job
+        :return: return data for annotations
+        """
+        result = self.send_request('jobs/%s/annotations' % job_id)
+        return result
+		
+    def calibrate_data(self,job_id):
+        """
+        :param job_id: id of job
+        :return: parity,orientation,pixscale,radius,ra, and dec
+        """
+        result = self.send_request('jobs/%s/calibration' % job_id)
+        return result
+
+    def sub_status(self, sub_id, justdict=False):
+        result = self.send_request('submissions/%s' % sub_id)
+        if justdict:
+            return result
+        return result.get('status')
+
+    def jobs_by_tag(self, tag, exact):
+        exact_option = 'exact=yes' if exact else ''
+        result = self.send_request(
+            'jobs_by_tag?query=%s&%s' % (quote(tag.strip()), exact_option),
+            {},
+        )
+        return result
+
+if __name__ == '__main__':
+    print("Running with args %s"%sys.argv)
+    import optparse
+    parser = optparse.OptionParser()
+    parser.add_option('--server', dest='server', default=Client.default_url,
+                      help='Set server base URL (eg, %default)')
+    parser.add_option('--apikey', '-k', dest='apikey',
+                      help='API key for Astrometry.net web service; if not given will check AN_API_KEY environment variable')
+    parser.add_option('--upload', '-u', dest='upload', help='Upload a file')
+    parser.add_option('--wait', '-w', dest='wait', action='store_true', help='After submitting, monitor job status')
+    parser.add_option('--wcs', dest='wcs', help='Download resulting wcs.fits file, saving to given filename; implies --wait if --urlupload or --upload')
+    parser.add_option('--newfits', dest='newfits', help='Download resulting new-image.fits file, saving to given filename; implies --wait if --urlupload or --upload')
+    parser.add_option('--corr', dest='corr', help='Download resulting corr.fits file, saving to given filename; implies --wait if --urlupload or --upload')
+    parser.add_option('--kmz', dest='kmz', help='Download resulting kmz file, saving to given filename; implies --wait if --urlupload or --upload')
+    parser.add_option('--annotate','-a',dest='annotate',help='store information about annotations in give file, JSON format; implies --wait if --urlupload or --upload')
+    parser.add_option('--calibrate','-C',dest='calibrate',help='store information about calibration in given file, JSON format; implies --wait if --urlupload or --upload')
+    parser.add_option('--urlupload', '-U', dest='upload_url', help='Upload a file at specified url')
+    parser.add_option('--scale-units', dest='scale_units',
+                      choices=('arcsecperpix', 'arcminwidth', 'degwidth', 'focalmm'), help='Units for scale estimate')
+    #parser.add_option('--scale-type', dest='scale_type',
+    #                  choices=('ul', 'ev'), help='Scale bounds: lower/upper or estimate/error')
+    parser.add_option('--scale-lower', dest='scale_lower', type=float, help='Scale lower-bound')
+    parser.add_option('--scale-upper', dest='scale_upper', type=float, help='Scale upper-bound')
+    parser.add_option('--scale-est', dest='scale_est', type=float, help='Scale estimate')
+    parser.add_option('--scale-err', dest='scale_err', type=float, help='Scale estimate error (in PERCENT), eg "10" if you estimate can be off by 10%')
+    parser.add_option('--ra', dest='center_ra', type=float, help='RA center')
+    parser.add_option('--dec', dest='center_dec', type=float, help='Dec center')
+    parser.add_option('--radius', dest='radius', type=float, help='Search radius around RA,Dec center')
+    parser.add_option('--downsample', dest='downsample_factor', type=int, help='Downsample image by this factor')
+    parser.add_option('--positional_error', dest='positional_error', type=float, help='How many pixels a star may be from where it should be.')
+    parser.add_option('--parity', dest='parity', choices=('0','1'), help='Parity (flip) of image')
+    parser.add_option('--tweak-order', dest='tweak_order', type=int, help='SIP distortion order (default: 2)')
+    parser.add_option('--crpix-center', dest='crpix_center', action='store_true', default=None, help='Set reference point to center of image?')
+    parser.add_option('--invert', action='store_true', default=None, help='Invert image before detecting sources -- for white-sky, black-stars images')
+    parser.add_option('--image-width', type=int, help='Set image width for x,y lists')
+    parser.add_option('--image-height', type=int, help='Set image height for x,y lists')
+    parser.add_option('--album', type=str, help='Add image to album with given title string')
+    parser.add_option('--sdss', dest='sdss_wcs', nargs=2, help='Plot SDSS image for the given WCS file; write plot to given PNG filename')
+    parser.add_option('--galex', dest='galex_wcs', nargs=2, help='Plot GALEX image for the given WCS file; write plot to given PNG filename')
+    parser.add_option('--jobid', '-i', dest='solved_id', type=int,help='retrieve result for jobId instead of submitting new image')
+    parser.add_option('--substatus', '-s', dest='sub_id', help='Get status of a submission')
+    parser.add_option('--jobstatus', '-j', dest='job_id', help='Get status of a job')
+    parser.add_option('--jobs', '-J', dest='myjobs', action='store_true', help='Get all my jobs')
+    parser.add_option('--jobsbyexacttag', '-T', dest='jobs_by_exact_tag', help='Get a list of jobs associated with a given tag--exact match')
+    parser.add_option('--jobsbytag', '-t', dest='jobs_by_tag', help='Get a list of jobs associated with a given tag')
+    parser.add_option( '--private', '-p',
+        dest='public',
+        action='store_const',
+        const='n',
+        default='y',
+        help='Hide this submission from other users')
+    parser.add_option('--allow_mod_sa','-m',
+        dest='allow_mod',
+        action='store_const',
+        const='sa',
+        default='d',
+        help='Select license to allow derivative works of submission, but only if shared under same conditions of original license')
+    parser.add_option('--no_mod','-M',
+        dest='allow_mod',
+        action='store_const',
+        const='n',
+        default='d',
+        help='Select license to disallow derivative works of submission')
+    parser.add_option('--no_commercial','-c',
+        dest='allow_commercial',
+        action='store_const',
+        const='n',
+        default='d',
+        help='Select license to disallow commercial use of submission')
+    opt,args = parser.parse_args()
+
+    if opt.apikey is None:
+        # try the environment
+        opt.apikey = os.environ.get('AN_API_KEY', None)
+    if opt.apikey is None:
+        parser.print_help()
+        print()
+        print('You must either specify --apikey or set AN_API_KEY')
+        sys.exit(-1)
+
+    args = {}
+    args['apiurl'] = opt.server
+    c = Client(**args)
+    c.login(opt.apikey)
+
+    if opt.upload or opt.upload_url:
+        if opt.wcs or opt.kmz or opt.newfits or opt.corr or opt.annotate or opt.calibrate:
+            opt.wait = True
+
+        kwargs = dict(
+            allow_commercial_use=opt.allow_commercial,
+            allow_modifications=opt.allow_mod,
+            publicly_visible=opt.public)
+        if opt.scale_lower and opt.scale_upper:
+            kwargs.update(scale_lower=opt.scale_lower,
+                          scale_upper=opt.scale_upper,
+                          scale_type='ul')
+        elif opt.scale_est and opt.scale_err:
+            kwargs.update(scale_est=opt.scale_est,
+                          scale_err=opt.scale_err,
+                          scale_type='ev')
+        elif opt.scale_lower or opt.scale_upper:
+            kwargs.update(scale_type='ul')
+            if opt.scale_lower:
+                kwargs.update(scale_lower=opt.scale_lower)
+            if opt.scale_upper:
+                kwargs.update(scale_upper=opt.scale_upper)
+
+        for key in ['scale_units', 'center_ra', 'center_dec', 'radius',
+                    'downsample_factor', 'positional_error', 'tweak_order', 'crpix_center',
+                    'album']:
+            if getattr(opt, key) is not None:
+                kwargs[key] = getattr(opt, key)
+        if opt.parity is not None:
+            kwargs.update(parity=int(opt.parity))
+
+        if opt.upload:
+            upres = c.upload(opt.upload, **kwargs)
+
+        if opt.upload_url:
+            upres = c.url_upload(opt.upload_url, **kwargs)
+
+        stat = upres['status']
+        if stat != 'success':
+            print('Upload failed: status', stat)
+            print(upres)
+            sys.exit(-1)
+
+        opt.sub_id = upres['subid']
+
+    if opt.wait:
+        if opt.solved_id is None:
+            if opt.sub_id is None:
+                print("Can't --wait without a submission id or job id!")
+                sys.exit(-1)
+
+            while True:
+                stat = c.sub_status(opt.sub_id, justdict=True)
+                print('Got status:', stat)
+                jobs = stat.get('jobs', [])
+                if len(jobs):
+                    for j in jobs:
+                        if j is not None:
+                            break
+                    if j is not None:
+                        print('Selecting job id', j)
+                        opt.solved_id = j
+                        break
+                time.sleep(5)
+
+        while True:
+            stat = c.job_status(opt.solved_id, justdict=True)
+            print('Got job status:', stat)
+            if stat.get('status','') in ['success']:
+                success = (stat['status'] == 'success')
+                break
+            elif stat.get('status','') in ['failure']:
+                print("Image solving failed")
+                sys.exit(-1)
+            time.sleep(5)
+
+    if opt.solved_id:
+        # we have a jobId for retrieving results
+        retrieveurls = []
+        if opt.wcs:
+            # We don't need the API for this, just construct URL
+            url = opt.server.replace('/api/', '/wcs_file/%i' % opt.solved_id)
+            retrieveurls.append((url, opt.wcs))
+        if opt.kmz:
+            url = opt.server.replace('/api/', '/kml_file/%i/' % opt.solved_id)
+            retrieveurls.append((url, opt.kmz))
+        if opt.newfits:
+            url = opt.server.replace('/api/', '/new_fits_file/%i/' % opt.solved_id)
+            retrieveurls.append((url, opt.newfits))
+        if opt.corr:
+            url = opt.server.replace('/api/', '/corr_file/%i' % opt.solved_id)
+            retrieveurls.append((url, opt.corr))
+
+        for url,fn in retrieveurls:
+            print('Retrieving file from', url, 'to', fn)
+            f = urlopen(url)
+            txt = f.read()
+            w = open(fn, 'wb')
+            w.write(txt)
+            w.close()
+            print('Wrote to', fn)
+
+        if opt.annotate:
+            result = c.annotate_data(opt.solved_id)
+            with open(opt.annotate,'w') as f:
+                f.write(python2json(result))
+				
+        if opt.calibrate:
+            result = c.calibrate_data(opt.solved_id)
+            with open(opt.calibrate,'w') as f:
+                f.write(python2json(result))
+
+    if opt.wait:
+        # behaviour as in old implementation
+        opt.sub_id = None
+
+    if opt.sdss_wcs:
+        (wcsfn, outfn) = opt.sdss_wcs
+        c.sdss_plot(outfn, wcsfn)
+    if opt.galex_wcs:
+        (wcsfn, outfn) = opt.galex_wcs
+        c.galex_plot(outfn, wcsfn)
+
+    if opt.sub_id:
+        print(c.sub_status(opt.sub_id))
+    if opt.job_id:
+        print(c.job_status(opt.job_id))
+
+    if opt.jobs_by_tag:
+        tag = opt.jobs_by_tag
+        print(c.jobs_by_tag(tag, None))
+    if opt.jobs_by_exact_tag:
+        tag = opt.jobs_by_exact_tag
+        print(c.jobs_by_tag(tag, 'yes'))
+
+    if opt.myjobs:
+        jobs = c.myjobs()
+        print(jobs)

--- a/register.py
+++ b/register.py
@@ -122,12 +122,12 @@ def solve(fn):
     # p.DetachFITS()
     
     #save the updated fits header to the first row horizon images
-    if (m<16) & (p.solved==True): 
-        f = fits.open(fn_orig,uint=False)
-        data = f[0].data.copy()
-        f.close()
-        header = fits.open(fn)[0].header
-        fits.writeto(fn_orig, data, header=header, overwrite=True)
+    # if (m<16) & (p.solved==True): 
+    #     f = fits.open(fn_orig,uint=False)
+    #     data = f[0].data.copy()
+    #     f.close()
+    #     header = fits.open(fn)[0].header
+    #     fits.writeto(fn_orig, data, header=header, overwrite=True)
         
     return message
 

--- a/register.py
+++ b/register.py
@@ -137,7 +137,6 @@ def solve(fn):
         '--wcs', f'{astsetp}{fn_base}_wcs.fit',
         '--private', '--no_commercial'
     ]
-    
     try: 
         response = subprocess.run(cmd, timeout=60)
         response.check_returncode()
@@ -164,7 +163,6 @@ def solve(fn):
             '--wcs', f'{astsetp}{fn_base}_wcs.fit',
             '--private', '--no_commercial'
         ]
-        
         try:
             response = subprocess.run(cmd, timeout=60)
             response.check_returncode()
@@ -203,7 +201,7 @@ def matchstars(dnight, sets, filter):
         
         #both V and B bands
         if filter == 'V':
-            files = glob(calsetp+'ib???.fit')[0:10]
+            files = glob(calsetp+'ib???.fit')
         elif filter == 'B':
             files = glob(calsetp+'B/ib???.fit')
         

--- a/register.py
+++ b/register.py
@@ -45,14 +45,14 @@ import filepath
 
 #-----------------------------------------------------------------------------#
 def solve(fn):
-    p = Dispatch('PinPoint.Plate')
-    p.Catalog = 4  # Tycho2 catalog
-    p.CatalogPath = filepath.catalog
+    #p = Dispatch('PinPoint.Plate')
+    #p.Catalog = 4  # Tycho2 catalog
+    #p.CatalogPath = filepath.catalog
     
-    if 'B' in fn:
-        p.colorband = 1 # B band
-    else: 
-        p.colorband = 2 # V band
+    # if 'B' in fn:
+    #     p.colorband = 1 # B band
+    # else: 
+    #     p.colorband = 2 # V band
     
     fn_orig = fn
     m = int(fn_orig[-7:-4])
@@ -67,25 +67,25 @@ def solve(fn):
         fn = fn[:-4]+'c.fit'
         f.writeto(fn, overwrite=True)
     
-    p.attachFits(fn)
-    p.ArcsecPerPixelHoriz = 96
-    p.ArcsecPerPixelVert = 96
-    p.SigmaAboveMean = 3
-    p.Minimumbrightness = 2500
-    p.FindImageStars()
+    # p.attachFits(fn)
+    # p.ArcsecPerPixelHoriz = 96
+    # p.ArcsecPerPixelVert = 96
+    # p.SigmaAboveMean = 3
+    # p.Minimumbrightness = 2500
+    # p.FindImageStars()
     
-    p.RightAscension = p.TargetRightAscension
-    p.Declination = p.TargetDeclination
+    # p.RightAscension = p.TargetRightAscension
+    # p.Declination = p.TargetDeclination
     
-    p.CatalogMaximumMagnitude = 7.
-    p.CatalogMinimumMagnitude = 2.
-    p.CatalogExpansion = 0.1
-    p.Maxsolvetime = 60
-    p.FindCatalogStars()
+    # p.CatalogMaximumMagnitude = 7.
+    # p.CatalogMinimumMagnitude = 2.
+    # p.CatalogExpansion = 0.1
+    # p.Maxsolvetime = 60
+    # p.FindCatalogStars()
     
     try: 
-        p.Solve()
-        p.UpdateFITS()
+        # p.Solve()
+        # p.UpdateFITS()
         message = ['normal', fn_orig] # files that have been solved normally
     except:
         # trying to just solve the cropped (200x200 pix) image
@@ -95,31 +95,31 @@ def solve(fn):
         fn = fn[:-4]+'s.fit'
         f.writeto(fn, overwrite=True)
         
-        p.DetachFITS()
-        p.attachFits(fn)
-        p.ArcsecPerPixelHoriz = 96
-        p.ArcsecPerPixelVert = 96
-        p.SigmaAboveMean = 2
-        p.Minimumbrightness = 2000
-        p.FindImageStars()
+        # p.DetachFITS()
+        # p.attachFits(fn)
+        # p.ArcsecPerPixelHoriz = 96
+        # p.ArcsecPerPixelVert = 96
+        # p.SigmaAboveMean = 2
+        # p.Minimumbrightness = 2000
+        # p.FindImageStars()
         
-        p.RightAscension = p.TargetRightAscension
-        p.Declination = p.TargetDeclination
+        # p.RightAscension = p.TargetRightAscension
+        # p.Declination = p.TargetDeclination
     
-        p.CatalogMaximumMagnitude = 9.
-        p.CatalogMinimumMagnitude = 2.
-        p.CatalogExpansion = 0.3
-        p.Maxsolvetime = 40
-        p.FindCatalogStars()
+        # p.CatalogMaximumMagnitude = 9.
+        # p.CatalogMinimumMagnitude = 2.
+        # p.CatalogExpansion = 0.3
+        # p.Maxsolvetime = 40
+        # p.FindCatalogStars()
         
         try:
-            p.Solve()
-            p.UpdateFITS()
+            # p.Solve()
+            # p.UpdateFITS()
             message = ['cropped',fn_orig] #files that have been cropped & solved
         except:
             message = ['failed', fn_orig] #files that haven been failed to solve
         
-    p.DetachFITS()
+    # p.DetachFITS()
     
     #save the updated fits header to the first row horizon images
     if (m<16) & (p.solved==True): 
@@ -133,9 +133,9 @@ def solve(fn):
 
 
 def matchstars(dnight, sets, filter):
-    p = Dispatch('PinPoint.Plate')
-    p.Catalog = 4  # Tycho2 catalog
-    p.CatalogPath = filepath.catalog
+    #p = Dispatch('PinPoint.Plate')
+    #p.Catalog = 4  # Tycho2 catalog
+    #p.CatalogPath = filepath.catalog
     
     cropped_fn = []
     failed_fn = []

--- a/register.py
+++ b/register.py
@@ -58,7 +58,7 @@ def solve(fn):
     m = int(fn_orig[-7:-4])
     
     if m in range(0,50,5): 
-        print 'Solving images %i/45'%m
+        print('Solving images %i/45'%m)
 
     # Masking the area near the horizon in image 0-15
     if m < 16: 
@@ -146,7 +146,7 @@ def matchstars(dnight, sets, filter):
     #looping through all the sets in that night
     for s in sets:
         calsetp = filepath.calibdata + dnight + '/S_0' + s[0] + '/'
-        print 'Registering images in', dnight + '/S_0' + s[0] + '...'
+        print('Registering images in', dnight + '/S_0' + s[0] + '...')
         
         #both V and B bands
         if filter == 'V':

--- a/register.py
+++ b/register.py
@@ -32,134 +32,193 @@
 #-----------------------------------------------------------------------------#
 
 from astropy.io import fits
-from datetime import datetime as Dtime
 from glob import glob, iglob
 from multiprocessing import Pool
-from win32com.client import Dispatch
 
-import pdb
+import os
+import time
+import subprocess
 import numpy as n
 
 # Local Source
 import filepath     
 
 #-----------------------------------------------------------------------------#
+
+def update_fits(fn, message):
+    """
+    Update original FITS file headers with 
+    Astrometry.net WCS solution.
+
+    Parameters
+    ----------
+    fn: str
+        FITS file sent to astrometry.net
+    message: list
+        [solve_status (str), fn_orig (str)]
+        2-element list containing the solve status
+        and the name of the original FITS file that
+        will be updated. The solve status can be
+        'normal', 'cropped', or 'failed'.
+
+    Returns
+    -------
+    None
+    """
+
+    # First parse the message
+    solve_status = message[0]
+    fn_orig = message[1]
+    if solve_status == 'failed':
+        return
+
+    # Get path to the WCS file
+    fn_base = fn.split("\\")[-1][:-4]
+    astsetp = "{:s}/astrometry/".format(fn.split("\\")[0])
+    fn_wcs = f"{astsetp}{fn_base}_wcs.fit"
+
+    # Load the WCS and original FITS headers
+    with fits.open(fn_wcs) as hdu:
+        wcs_hdr = hdu[0].header
+    with fits.open(fn_orig) as hdu:
+        orig_hdr = hdu[0].header
+
+    # Update header value if a cropped image was used
+    if solve_status == 'cropped':
+        wcs_hdr['CRPIX1'] = wcs_hdr['CRPIX1'] + int(orig_hdr['NAXIS1']/2) - 100
+        wcs_hdr['CRPIX2'] = wcs_hdr['CRPIX2'] + int(orig_hdr['NAXIS2']/2) - 100
+        
+    # Header keys to save
+    wcs_keys = [
+        'WCSAXES', 'CTYPE1', 'CTYPE2','EQUINOX','LONPOLE','LATPOLE',
+        'CRVAL1','CRVAL2','CRPIX1','CRPIX2','CUNIT1','CUNIT2',
+        'CD1_1','CD1_2','CD2_1','CD2_2',
+        'A_ORDER','A_0_0','A_0_1','A_0_2','A_1_0','A_1_1','A_2_0',
+        'B_ORDER','B_0_0','B_0_1','B_0_2','B_1_0','B_1_1','B_2_0',
+        'AP_ORDER','AP_0_0','AP_0_1','AP_0_2','AP_1_0','AP_1_1','AP_2_0',
+        'BP_ORDER','BP_0_0','BP_0_1','BP_0_2','BP_1_0','BP_1_1','BP_2_0'
+    ]
+
+    # Update original FITS file's header
+    with fits.open(fn_orig, uint=False, mode='update') as hdul:
+        for key in wcs_keys:
+            if key not in list(wcs_hdr.keys()):
+                continue
+            hdul[0].header[key] = wcs_hdr[key]
+            hdul[0].header.comments[key] = wcs_hdr.comments[key]
+        hdul.flush()
+
+
 def solve(fn):
-    #p = Dispatch('PinPoint.Plate')
-    #p.Catalog = 4  # Tycho2 catalog
-    #p.CatalogPath = filepath.catalog
-    
-    # if 'B' in fn:
-    #     p.colorband = 1 # B band
-    # else: 
-    #     p.colorband = 2 # V band
     
     fn_orig = fn
+    astsetp = "%s/astrometry/"%(fn.split("\\")[0])
     m = int(fn_orig[-7:-4])
-    
-    if m in range(0,50,5): 
-        print('Solving images %i/45'%m)
 
     # Masking the area near the horizon in image 0-15
     if m < 16: 
-        f = fits.open(fn,uint=False)[0]
-        f.data[630:] = 0.
-        fn = fn[:-4]+'c.fit'
-        f.writeto(fn, overwrite=True)
-    
-    # p.attachFits(fn)
-    # p.ArcsecPerPixelHoriz = 96
-    # p.ArcsecPerPixelVert = 96
-    # p.SigmaAboveMean = 3
-    # p.Minimumbrightness = 2500
-    # p.FindImageStars()
-    
-    # p.RightAscension = p.TargetRightAscension
-    # p.Declination = p.TargetDeclination
-    
-    # p.CatalogMaximumMagnitude = 7.
-    # p.CatalogMinimumMagnitude = 2.
-    # p.CatalogExpansion = 0.1
-    # p.Maxsolvetime = 60
-    # p.FindCatalogStars()
+        with fits.open(fn,uint=False) as hdul:
+            f = hdul[0]
+            f.data[630:] = 0.
+            fn = fn[:-4]+'c.fit'
+            f.writeto(fn, overwrite=True)
+
+    #solve for astrometry; see "python client.py -help"
+    fn_base = fn.split("\\")[-1][:-4]
+    cmd = [
+        'python', 'client.py', 
+        '--apikey', f'{filepath.apikey}',
+        '--upload', f'{fn}',
+        '--parity', '1',
+        '--scale-est', '96.0',
+        '--corr', f'{astsetp}{fn_base}_corr.fit',
+        '--calibrate', f'{astsetp}{fn_base}_calib.txt',
+        '--wcs', f'{astsetp}{fn_base}_wcs.fit'
+    ]
     
     try: 
-        # p.Solve()
-        # p.UpdateFITS()
+        response = subprocess.run(cmd, timeout=60)
+        response.check_returncode()
         message = ['normal', fn_orig] # files that have been solved normally
-    except:
+    except Exception as e:
         # trying to just solve the cropped (200x200 pix) image
-        f = fits.open(fn,uint=False)[0]
-        l = len(f.data)/2
-        f.data = f.data[l-100:l+100,l-100:l+100]
-        fn = fn[:-4]+'s.fit'
-        f.writeto(fn, overwrite=True)
-        
-        # p.DetachFITS()
-        # p.attachFits(fn)
-        # p.ArcsecPerPixelHoriz = 96
-        # p.ArcsecPerPixelVert = 96
-        # p.SigmaAboveMean = 2
-        # p.Minimumbrightness = 2000
-        # p.FindImageStars()
-        
-        # p.RightAscension = p.TargetRightAscension
-        # p.Declination = p.TargetDeclination
-    
-        # p.CatalogMaximumMagnitude = 9.
-        # p.CatalogMinimumMagnitude = 2.
-        # p.CatalogExpansion = 0.3
-        # p.Maxsolvetime = 40
-        # p.FindCatalogStars()
+        with fits.open(fn,uint=False) as hdul:
+            f = hdul[0]
+            l = int(len(f.data)/2)
+            f.data = f.data[l-100:l+100,l-100:l+100]
+            fn = fn[:-4]+'s.fit'
+            f.writeto(fn, overwrite=True)
+
+        #solve for astrometry; see "python client.py -help"
+        fn_base = fn.split("\\")[-1][:-4]
+        cmd = [
+            'python', 'client.py', 
+            '--apikey', f'{filepath.apikey}',
+            '--upload', f'{fn}',
+            '--parity', '1',
+            '--scale-est', '96.0',
+            '--corr', f'{astsetp}{fn_base}_corr.fit',
+            '--calibrate', f'{astsetp}{fn_base}_calib.txt',
+            '--wcs', f'{astsetp}{fn_base}_wcs.fit'
+        ]
         
         try:
-            # p.Solve()
-            # p.UpdateFITS()
+            response = subprocess.run(cmd, timeout=60)
+            response.check_returncode()
             message = ['cropped',fn_orig] #files that have been cropped & solved
-        except:
+        except Exception as e:
             message = ['failed', fn_orig] #files that haven been failed to solve
-        
-    # p.DetachFITS()
-    
-    #save the updated fits header to the first row horizon images
-    # if (m<16) & (p.solved==True): 
-    #     f = fits.open(fn_orig,uint=False)
-    #     data = f[0].data.copy()
-    #     f.close()
-    #     header = fits.open(fn)[0].header
-    #     fits.writeto(fn_orig, data, header=header, overwrite=True)
+
+    # Update the original FITS headers
+    update_fits(fn, message)
         
     return message
 
 
 def matchstars(dnight, sets, filter):
-    #p = Dispatch('PinPoint.Plate')
-    #p.Catalog = 4  # Tycho2 catalog
-    #p.CatalogPath = filepath.catalog
     
     cropped_fn = []
     failed_fn = []
     l_dir = len(filepath.calibdata+dnight)+1
     
-    pool = Pool()
+    pool = Pool(processes=5)
 
     #looping through all the sets in that night
+    t0 = time.time()
     for s in sets:
+
+        # Get paths to FITS images and astrometry directory
         calsetp = filepath.calibdata + dnight + '/S_0' + s[0] + '/'
+        astsetp = f'{calsetp}astrometry/'
         print('Registering images in', dnight + '/S_0' + s[0] + '...')
+
+        # Create astrometry directory if needed
+        if not os.path.exists(astsetp):
+            os.mkdir(astsetp)
         
         #both V and B bands
         if filter == 'V':
-            file = glob(calsetp+'ib???.fit')
+            files = glob(calsetp+'ib???.fit')
         elif filter == 'B':
-            file = glob(calsetp+'B/ib???.fit')
+            files = glob(calsetp+'B/ib???.fit')
+
+        # Serial execution
+        # for file in files:
+        #     result = solve(file)
+        #     if result[0] == 'cropped':
+        #         cropped_fn.append(result[1])
+        #     elif result[0] == 'failed':
+        #         failed_fn.append(result[1])
         
-        result = n.array(pool.map(solve,file))
+        result = n.array(pool.map(solve,files))
         cropped_fn.extend(result[:,1][n.where(result[:,0]=='cropped')])
         failed_fn.extend(result[:,1][n.where(result[:,0]=='failed')])
         
     pool.close()
     pool.join()
+    t1 = time.time()
+    print('  Solving time = {:.2f} minutes'.format((t1-t0)/60))
+
     return(cropped_fn, failed_fn)
     
     


### PR DESCRIPTION
Python 2.x to 3.x updates and removed dependencies on the ACP observatory Control Software. Script now uses astrometry.net API (via the new `client.py` script added here). All astrometry.net files are saved into an astrometry folder within the `.../calibdata/<night>/<set>` directory, and the original FITS images are updated with the astrometry.net WCS solution.

Script uses multiprocessing, currently allowing 5 parallel calls to the astrometry.net API. A single set (45 images) can be processed in about 5-minutes. Some network problems are occasionally encountered with solving images or retrieving the resulting data products. This could possibly be solved by running fewer parallel processes, but needs further testing.