### PR TITLE
Improve Raster Clipping with Custom Borders

### DIFF
--- a/fullmosaic.py
+++ b/fullmosaic.py
@@ -237,7 +237,7 @@ def mosaic(dnight, sets, filter):
             outSetNull = arcpy.sa.SetNull(
                 'ibw%03d.tif' %v, 
                 'ibw%03d.tif' %v, 
-                "VALUE = 0"
+                "VALUE <= 0"
             )
             outSetNull.save('ibw%03d.tif' %v)
 
@@ -254,7 +254,7 @@ def mosaic(dnight, sets, filter):
             outSetNull = arcpy.sa.SetNull(
                 'fwib%03d.tif' %v, 
                 'fwib%03d.tif' %v, 
-                "VALUE = 0"
+                "VALUE <= 0"
             )
             outSetNull.save('fwib%03d.tif' %v)
 

--- a/fullmosaic.py
+++ b/fullmosaic.py
@@ -144,13 +144,13 @@ def set_null_values(rasterFile):
     outSetNull.save(rasterFile)
 
 
-
 def remove_readonly(func, path, excinfo):
     '''
     Error-catching function to handle removal of read-only folders
     '''
     os.chmod(path, stat.S_IWRITE)
     func(path)
+  
   
 def clear_dir(dir_path):
     '''

--- a/fullmosaic.py
+++ b/fullmosaic.py
@@ -59,6 +59,7 @@ arcpy.env.rasterStatistics = "NONE"
 arcpy.env.overwriteOutput = True
 arcpy.env.pyramid = "NONE"
 arcpy.env.compression = "NONE"
+arcpy.CheckOutExtension("3D")
 
 # define source control points (37 points total, units = meters)
 ########################
@@ -138,12 +139,12 @@ def remove_readonly(func, path, excinfo):
     os.chmod(path, stat.S_IWRITE)
     func(path)
   
-def clear_scratch(scratch_dir):
+def clear_dir(dir_path):
     '''
     Function to clear out all files and folders from
-    the scratch directory.
+    the specified directory.
     '''
-    for root, dirs, files in os.walk(scratch_dir, topdown=False):
+    for root, dirs, files in os.walk(dir_path, topdown=False):
         for name in files:
             os.remove(os.path.join(root, name))
         for name in dirs:
@@ -166,15 +167,25 @@ def mosaic(dnight, sets, filter):
     
     for s in sets:
 
-        #clear scratch directory
-        clear_scratch(filepath.rasters+'scratch_fullres/')
+        # Define file paths
+        calsetp = f"{filepath.calibdata}{dnight}/S_0{s[0]}/{F[filter]}"
+        gridsetp = f"{filepath.griddata}{dnight}/S_0{s[0]}/{F[filter]}fullres/"
+        scratchsetp = f"{filepath.rasters}scratch_fullres/"
+        domainsetp = f"{calsetp}/domains/"
 
-        #file paths
-        calsetp = filepath.calibdata+dnight+'/S_0%s/%s' %(s[0],F[filter])
-        gridsetp = filepath.griddata+dnight+'/S_0%s/%sfullres/' %(s[0],F[filter])
+        # Remove and/or create gridsetp directory
         if os.path.exists(gridsetp):
             shutil.rmtree(gridsetp, onerror=remove_readonly)
         os.makedirs(gridsetp)
+
+        # Create domainsetp if non-existent, else clear out directory
+        if not os.path.exists(domainsetp):
+            os.makedirs(domainsetp)
+        else:
+            clear_dir(domainsetp)
+
+        # Clear out the scratch directory
+        clear_dir(scratchsetp)
                 
         #read in the registered images coordinates
         file = filepath.calibdata+dnight+'/pointerr_%s.txt' %s[0]
@@ -222,6 +233,14 @@ def mosaic(dnight, sets, filter):
                 "BILINEAR"
             )
 
+            #set zero values to NoData
+            outSetNull = arcpy.sa.SetNull(
+                'ibw%03d.tif' %v, 
+                'ibw%03d.tif' %v, 
+                "VALUE = 0"
+            )
+            outSetNull.save('ibw%03d.tif' %v)
+
             # Reproject into GCS
             arcpy.management.ProjectRaster(
                 'ibw%03d.tif' %v, 
@@ -230,12 +249,46 @@ def mosaic(dnight, sets, filter):
                 "BILINEAR", 
                 "0.0261"
             )
+
+            # Set zero values to NoData
+            outSetNull = arcpy.sa.SetNull(
+                'fwib%03d.tif' %v, 
+                'fwib%03d.tif' %v, 
+                "VALUE = 0"
+            )
+            outSetNull.save('fwib%03d.tif' %v)
+
+            # Create a raster border for clipping
+            os.makedirs(f'{domainsetp}ib{v:03d}/')
+            arcpy.ddd.RasterDomain(
+                f'fwib{v:03d}.tif',
+                f'{domainsetp}ib{v:03d}/ib{v:03d}_domain',
+                'POLYGON'
+            )
+            arcpy.management.EliminatePolygonPart(
+                f'{domainsetp}ib{v:03d}/ib{v:03d}_domain',
+                f'{domainsetp}ib{v:03d}/ib{v:03d}_border',
+                "PERCENT",
+                "",
+                "10",
+                "CONTAINED_ONLY"
+            )
                                        
             # Clip to image boundary
-            rectangle = clip_envelope(Obs_AZ, Obs_ALT, w)
-            arcpy.management.Clip("fwib%03d.tif"%v, rectangle, "fcib%03d"%v)
+            # rectangle = clip_envelope(Obs_AZ, Obs_ALT, w)
+            # arcpy.management.Clip("fwib%03d.tif"%v, rectangle, "fcib%03d"%v)
+            clipFile = f'{domainsetp}ib{v:03d}/ib{v:03d}_border'
+            arcpy.management.Clip(
+                f"fwib{v:03d}.tif", 
+                "", 
+                f"fcib{v:03d}", 
+                clipFile,
+                "0",
+                "ClippingGeometry",
+                "NO_MAINTAIN_EXTENT"
+            )
             
-        #mosaic raster list must start with an image with max pixel value > 256
+        # Mosaic raster list must start with an image with max pixel value > 256
         v=1; mstart=1
         while v < (len(Obs_AZ)+1):
             tiff = Image.open(filepath.rasters+'scratch_fullres/ib%03d.tif' %v)
@@ -245,34 +298,41 @@ def mosaic(dnight, sets, filter):
                 break
             v+=1
                         
-        #mosaic raster list
+        # Mosaic raster list
         R1 = ';'.join(['fcib%03d' %i for i in range(mstart,47)])
         R2 = ';'.join(['fcib%03d' %i for i in range(1,mstart)])
         R = R1+';'+R2
 
-        #mosaic to topocentric coordinate image; save in Griddata\
+        # Mosaic to topocentric coordinate image; save in Griddata\
         print("Mosaicking into all sky full-resolution image...")
         arcpy.management.MosaicToNewRaster(
             R, gridsetp, 'skytopo', geogcs, 
             "32_BIT_FLOAT", "0.0261", "1", "BLEND", "FIRST"
         )
+
+        # Crop lower latitude limit to -6.0 degrees
+        arcpy.management.Clip(
+            f'{gridsetp}skytopo', 
+            "-180.000 -6.000 180.000 90.000", 
+            f'{gridsetp}skytopoc'
+        )
         
-        #convert to magnitudes per square arc second
+        # Convert to magnitudes per square arc second
         print("Converting the mosaic to mag per square arcsec...")
         psa = 2.5*n.log10((platescale[int(s[0])-1]*60)**2) # platescale adjustment
-        stm1 = arcpy.sa.Raster(gridsetp + os.sep + 'skytopo')
+        stm1 = arcpy.sa.Raster(gridsetp + os.sep + 'skytopoc')
         stm2 = stm1 / exptime[0]
         stm3 = arcpy.sa.Log10(stm2)
         stm4 = 2.5 * stm3
         skytopomags = zeropoint[int(s[0])-1] + psa - stm4
 
-        #save mags mosaic to disk
+        # Save mags mosaic to disk
         skytopomags.save(gridsetp + os.sep + 'skytopomags')
     
         print("Creating layer files for full-resolution mosaic...")
         layerName = dnight+'_%s_fullres%s'%(s[0],f[filter])
-        layerfile = filepath.griddata+dnight+'/skytopomags%s%s.lyr' %(f[filter],s[0])
-        symbologyLayer = filepath.rasters+'magnitudes.lyr'
+        layerfile = filepath.griddata+dnight+'/skytopomags%s%s.lyrx' %(f[filter],s[0])
+        symbologyLayer = filepath.rasters+'magnitudes.lyrx'
         arcpy.management.MakeRasterLayer(gridsetp+'skytopomags', layerName)
         arcpy.management.ApplySymbologyFromLayer(layerName, symbologyLayer)
         arcpy.management.SaveToLayerFile(layerName, layerfile, "RELATIVE")

--- a/medianmosaic.py
+++ b/medianmosaic.py
@@ -174,9 +174,6 @@ def mosaic(dnight, sets, filter):
     
     for s in sets:
 
-        #clear scratch directory
-        clear_scratch(filepath.rasters+'scratch_median/')
-
         # Define file paths
         calsetp = f"{filepath.calibdata}{dnight}/S_0{s[0]}/{F[filter]}"
         gridsetp = f"{filepath.griddata}{dnight}/S_0{s[0]}/{F[filter]}median/"
@@ -234,7 +231,7 @@ def mosaic(dnight, sets, filter):
                 "BILINEAR"
             )
 
-            #set zero values to NoData
+            # Set any zero values created during Warp to NoData
             outSetNull = arcpy.sa.SetNull(
                 'ibw%03d.tif' %v, 
                 'ibw%03d.tif' %v, 
@@ -245,21 +242,21 @@ def mosaic(dnight, sets, filter):
             #reproject into GCS
             arcpy.management.ProjectRaster(
                 'ibw%03d.tif' %v, 
-                'wib%03d.tif' %v, 
+                'fwib%03d.tif' %v, 
                 geogcs, 
                 "BILINEAR", 
                 "0.0266"
             )
 
-            #set zero values to NoData
+            # Set any zero values created by projection to NoData
             outSetNull = arcpy.sa.SetNull(
-                'wib%03d.tif' %v, 
-                'wib%03d.tif' %v, 
+                'fwib%03d.tif' %v, 
+                'fwib%03d.tif' %v, 
                 "VALUE <= 0"
             )
-            outSetNull.save('nwib%03d.tif' %v)
+            outSetNull.save('fwib%03d.tif' %v)
                                        
-            #clip to image boundary
+            # Clip to image boundary
             # rectangle = clip_envelope(Obs_AZ, Obs_ALT, w)
             # arcpy.management.Clip("wib%03d.tif"%v, rectangle, "cib%03d"%v)
             clipFile = f'{domainsetp}ib{v:03d}/ib{v:03d}_border'
@@ -284,8 +281,8 @@ def mosaic(dnight, sets, filter):
             v+=1
                         
         #mosaic raster list
-        R1 = ';'.join(['nwib%03d.tif' %i for i in range(mstart,47)])
-        R2 = ';'.join(['nwib%03d.tif' %i for i in range(1,mstart)])
+        R1 = ';'.join(['fcib%03d' %i for i in range(mstart,47)])
+        R2 = ';'.join(['fcib%03d' %i for i in range(1,mstart)])
         R = R1+';'+R2
         
         #mosaic to topocentric coordinate image; save in Griddata\

--- a/reduce.py
+++ b/reduce.py
@@ -45,6 +45,17 @@ import filepath
 
 #-----------------------------------------------------------------------------#
 
+def stretch_to_range(values, new_min, new_max):
+    '''
+    Function to perform a linear stretch of an array of values 
+    to fit within a new min and max range.
+    '''
+    old_min = min(values.flatten())
+    old_max = max(values.flatten())
+    new_values = ((values - old_min) / (old_max - old_min)) * (new_max - new_min) + new_min
+    return new_values
+
+
 def reducev(dnight, sets, flatname, curve):
     '''
     This module is for calibrating the V-band data.
@@ -124,6 +135,8 @@ def reducev(dnight, sets, flatname, curve):
                 f.data *= n.interp(f.data,xp,fp)      # correct for linearity response
                 f.data -= corthermal                  # subtract dark
                 f.data /= flat                        # divide by flat
+                f.data = f.data.clip(min=1.0)         # Set minimum value to 1
+                f.data = f.data.astype(n.uint16)      # Convert to uint16 values
                 f.header['IMAGETYP'] = 'CALIB_M'      # Update header
                 f.writeto(calsetp+file[i][len(rawsetp):], overwrite=True)
 
@@ -186,6 +199,8 @@ def reduceb(dnight, sets, flatname, curve):
             f.data *= n.interp(f.data,xp,fp)      # correct for linearity response
             f.data -= corthermal                  # subtract dark
             f.data /= flat                        # divide by flat
+            f.data = f.data.clip(min=1.0)         # Set minimum value to 1
+            f.data = f.data.astype(n.uint16)      # Convert to uint16 values
             f.header['IMAGETYP'] = 'CALIB_M'
             f.writeto(calsetp+file[i][len(rawsetp):-5]+'.fit', overwrite=True)
 

--- a/register.py
+++ b/register.py
@@ -196,7 +196,7 @@ def solve(fn):
         '--corr', f'{astsetp}{fn_base}_corr.fit',
         '--calibrate', f'{astsetp}{fn_base}_calib.txt',
         '--wcs', f'{astsetp}{fn_base}_wcs.fit',
-        '--wait-time', '120.0',
+        '--wait-time', '300.0',
         '--crpix-center'
     ]
     try: 

--- a/register.py
+++ b/register.py
@@ -223,7 +223,7 @@ def solve(fn):
             '--corr', f'{astsetp}{fn_base}_corr.fit',
             '--calibrate', f'{astsetp}{fn_base}_calib.txt',
             '--wcs', f'{astsetp}{fn_base}_wcs.fit',
-            '--wait-time', '120.0',
+            '--wait-time', '300.0',
             '--crpix-center'
         ]
         try:

--- a/zodiacal.py
+++ b/zodiacal.py
@@ -132,15 +132,18 @@ def mosaic(dnight, sets):
 
     for s in sets:
 
-        # Clear out scratch directory
-        clear_scratch(f'{filepath.rasters}scratch_zodiacal/')
-
-        #file paths
+        # Define file paths
         calsetp = filepath.calibdata+dnight+'/S_0%s/' %s[0]
         gridsetp = filepath.griddata+dnight+'/S_0%s/zod/' %s[0]
+        scratchsetp = f"{filepath.rasters}scratch_zodiacal/"
+        domainsetp = f"{calsetp}/S_0{s[0]}/domains/"
+
         if os.path.exists(gridsetp):
             shutil.rmtree(gridsetp, onerror=remove_readonly)
         os.makedirs(gridsetp)
+
+        # Clear out scratch directory
+        clear_scratch(scratchsetp)
         
         #read in the zodiacal coordinates from coordinates_%s.txt
         file = filepath.calibdata+dnight+'/coordinates_%s.txt'%s[0]
@@ -187,8 +190,18 @@ def mosaic(dnight, sets):
             )
 
             #clip to image boundary
-            rectangle = clip_envelope(Obs_AZ, Obs_ALT, w)
-            arcpy.management.Clip("zod%02d.tif"%v, rectangle, "zodi%02d"%v)
+            # rectangle = clip_envelope(Obs_AZ, Obs_ALT, w)
+            # arcpy.management.Clip("zod%02d.tif"%v, rectangle, "zodi%02d"%v)
+            clipFile = f'{domainsetp}ib{v:03d}/ib{v:03d}_border'
+            arcpy.management.Clip(
+                f"zod{v:02d}.tif", 
+                "", 
+                f"zodi{v:02d}", 
+                clipFile,
+                "0",
+                "ClippingGeometry",
+                "NO_MAINTAIN_EXTENT"
+            )
             
         #Mosaic to topocentric coordinate model; save in Griddata\
         print("Mosaicking into all sky zodiacal model...")
@@ -197,10 +210,21 @@ def mosaic(dnight, sets):
             R, gridsetp, 'zodtopo', geogcs, 
             "32_BIT_FLOAT", "0.1", "1", "BLEND", "FIRST"
         )
+
+        # Crop lower latitude limit to -6.0 degrees
+        arcpy.management.Clip(
+            f'{gridsetp}zodtopo', 
+            "-180.000 -6.000 180.000 90.000", 
+            f'{gridsetp}zodtopoc'
+        )
                                         
         #re-sampling to 0.05 degree resolution
         gridname = gridsetp + "zodtopmags"
-        arcpy.management.Resample(gridsetp+'zodtopo',gridname,'0.05','BILINEAR')
+        arcpy.management.Resample(
+            gridsetp+'zodtopoc',
+            gridname,'0.05',
+            'BILINEAR'
+        )
     
         #Create Raster layer, add magnitudes symbology, and save layer to file
         print("Creating layer files for zodiacal mosaic...")

--- a/zodiacal.py
+++ b/zodiacal.py
@@ -136,7 +136,7 @@ def mosaic(dnight, sets):
         calsetp = filepath.calibdata+dnight+'/S_0%s/' %s[0]
         gridsetp = filepath.griddata+dnight+'/S_0%s/zod/' %s[0]
         scratchsetp = f"{filepath.rasters}scratch_zodiacal/"
-        domainsetp = f"{calsetp}/S_0{s[0]}/domains/"
+        domainsetp = f"{calsetp}domains/"
 
         if os.path.exists(gridsetp):
             shutil.rmtree(gridsetp, onerror=remove_readonly)


### PR DESCRIPTION
Rectangle clipping of rasters used as input to the Arcpy mosaic function was occasionally producing corners that lacked data, resulting in holes in the final all-sky mosaics. This pull request introduces a new clipping method where custom polygon boundaries are produced for each image based on the true image extent. These boundaries are produced when the `fullmosaic.py` script is run and saved within Calibdata in a new "domains" sub-folder (e.g. `.../Calibdata/ROMO241004/S_01/domains/`. The `medianmosaic.py`, `galactic.py`, and `zodiacal.py` scripts will then load these boundaries when they are run so that the same clipping extents are used for each mosaic. This means that the `fullmosaic.py` script must be run first before the other mosaicking scripts are run, whereas before all mosaicking scripts could be run concurrently.